### PR TITLE
allow rtmp protocol

### DIFF
--- a/gridplayer/models/video_uri.py
+++ b/gridplayer/models/video_uri.py
@@ -7,7 +7,7 @@ from gridplayer.params.extensions import SUPPORTED_MEDIA_EXT
 
 
 class VideoURL(AnyUrl):
-    allowed_schemes = {"http", "https", "rtp", "rtsp", "udp", "mms", "mmsh"}
+    allowed_schemes = {"http", "https", "rtp", "rtsp", "rtmp", "udp", "mms", "mmsh"}
     max_length = 2083
 
 


### PR DESCRIPTION
Since vlc itself supports the rtmp protocol, this change simply allows the rtmp protocol