### PR TITLE
Bump dep versions, some improvements ...

### DIFF
--- a/gridplayer/models/resolver_patterns.py
+++ b/gridplayer/models/resolver_patterns.py
@@ -55,13 +55,13 @@ class ResolverPattern(BaseModel):
 
 
 class ResolverPatterns(BaseModel):
-    __root__: List[ResolverPattern]
+    RootModel: List[ResolverPattern]
 
     def __iter__(self) -> Iterable[ResolverPattern]:
-        return iter(self.__root__)
+        return iter(self.RootModel)
 
     def get_resolver(self, url: str) -> Optional[URLResolver]:
-        for pattern in self.__root__:
+        for pattern in self.RootModel:
             if pattern.is_match(url):
                 return pattern.resolver
 

--- a/gridplayer/models/video_uri.py
+++ b/gridplayer/models/video_uri.py
@@ -1,35 +1,22 @@
-from pathlib import Path
 from typing import Union
 
-from pydantic import AnyUrl, FilePath, PydanticValueError
+from pydantic import AnyUrl, ValidationError
 
 from gridplayer.params.extensions import SUPPORTED_MEDIA_EXT
 
 
 class VideoURL(AnyUrl):
-    allowed_schemes = {"http", "https", "rtp", "rtsp", "rtmp", "udp", "mms", "mmsh"}
     max_length = 2083
 
 
-class PathNotAbsoluteError(PydanticValueError):
+class PathNotAbsoluteError(ValidationError):
     code = "path.not_absolute"
     msg_template = 'path "{path}" is not absolute'
 
 
-class PathExtensionNotSupportedError(PydanticValueError):
+class PathExtensionNotSupportedError(ValidationError):
     code = "path.ext_not_supported"
     msg_template = 'path extension "{path}" is not supported'
 
 
-class AbsoluteFilePath(FilePath):
-    @classmethod
-    def validate(cls, path: Path) -> Path:
-        super().validate(path)
-
-        if not path.is_absolute():
-            raise PathNotAbsoluteError(path=path)
-
-        return path
-
-
-VideoURI = Union[VideoURL, AbsoluteFilePath]
+VideoURI = Union[VideoURL]

--- a/gridplayer/settings.py
+++ b/gridplayer/settings.py
@@ -77,7 +77,7 @@ _default_settings = {
     "internal/fake_overlay_invisibility": False,
     "streaming/hls_via_streamlink": True,
     "streaming/resolver_priority": URLResolver.STREAMLINK,
-    "streaming/resolver_priority_patterns": ResolverPatterns(__root__=[]),
+    "streaming/resolver_priority_patterns": ResolverPatterns(RootModel = []),
     "recent_list_videos": RecentListVideos(),
     "recent_list_playlists": RecentListPlaylists(),
 }

--- a/gridplayer/utils/files.py
+++ b/gridplayer/utils/files.py
@@ -25,10 +25,7 @@ def extract_mime_uris(dnd_data: QMimeData) -> List[str]:
 
     if dnd_data.hasUrls():
         for url in dnd_data.urls():
-            if url.isLocalFile():
-                uris.append(url.toLocalFile())
-            else:
-                uris.append(url.url())
+            uris.append(url.url())
 
     elif dnd_data.hasText():
         dnd_text = dnd_data.text().splitlines()

--- a/poetry.lock
+++ b/poetry.lock
@@ -879,27 +879,11 @@ PyQt5-sip = ">=12.15,<13"
 
 [[package]]
 name = "pyqt5-qt5"
-version = "5.15.2"
-description = "The subset of a Qt installation needed by PyQt5."
-optional = false
-python-versions = "*"
-groups = ["main"]
-markers = "sys_platform != \"darwin\""
-files = [
-    {file = "PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154"},
-    {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
-    {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
-    {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
-]
-
-[[package]]
-name = "pyqt5-qt5"
 version = "5.15.18"
 description = "The subset of a Qt installation needed by PyQt5."
 optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
 files = [
     {file = "pyqt5_qt5-5.15.18-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:8bb997eb903afa9da3221a0c9e6eaa00413bbeb4394d5706118ad05375684767"},
     {file = "pyqt5_qt5-5.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c656af9c1e6aaa7f59bf3d8995f2fa09adbf6762b470ed284c31dca80d686a26"},
@@ -1319,4 +1303,4 @@ test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "73eee858297cdca5c7ead7754d25a820791dc022803a708c99f5d7c889d99c86"
+content-hash = "bda2a7ea390523c1d4d9438d3714d4ba6d928c6602c010b92fb33d01cacdbb92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,12 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "PyQt5==5.15.11",
-    "PyQt5-Qt5==5.15.2 ; sys_platform == 'win32'",
-    "PyQt5-Qt5==5.15.2 ; sys_platform == 'linux'",
-    "PyQt5-Qt5==5.15.18 ; sys_platform == 'darwin'",
+    "PyQt5",
+    "PyQt5-Qt5",
     "pydantic>=1.8.2",
     "python-vlc==3.0.11115",
-    "streamlink==8.0.0",
-    "yt-dlp==2025.11.12",
+    "streamlink",
+    "yt-dlp",
     "pyobjc-core ; sys_platform == 'darwin'",
     "pyobjc-framework-Cocoa ; sys_platform == 'darwin'",
 ]


### PR DESCRIPTION
Presenting some changes that might be useful. I don't expect it to be merged. Just want to help out a little.

Maybe remove yt-dlp entirely and have the user install it manually. I think users don't even realise you can use youtube links and many of the users don't even need the feature. yt-dlp is quite heavy.

I don't know why local files are handled differently. I presume it's because of Windows?

```
- Bump Pydantic to 2.12, fix errors
- Remove separate local File class. QtUrl SHOULD return local files in file://... scheme. If not, polyfill is required. VLC is able to handle file://
- VideoURL: do not impose url scheme limitation on VLC. Pass the url through and let VLC decide whether it can handle it or not (Any encoding erorr, container format error, connection error can only be determined by the VLC process itself in the first place)
- Use the latest yt-dlp. Youtube is constantly changing programatic access detection algorithm and the only way to keep up with it is to using the nightly build of yt-dlp
- Remove other dependency package version spec. The only package to worry about is python-vlc. If any other dep makes any trouble, we're screwed anyway
```