### PR TITLE
build: add native Apple Silicon (arm64) macOS build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+* Native Apple Silicon (arm64) macOS build support, with arch-aware build scripts and a `BUILD_MACOS_ARCH` override for Intel (`x86_64`) builds
+
 ## [0.5.4] - 2025-11-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,14 +40,17 @@ just build-win-package
 Install dependencies:
 
 ```bash
-.\scripts\macos\_init_local_env.sh
+./scripts/macos/_init_local_env.sh
 ```
 
-Build:
+Build the native Apple Silicon package:
 
 ```bash
-just build-macos-package
+just build-macos-package-arm64
 ```
+
+The default macOS build target is `arm64`. If you need an Intel build, run the same
+scripts from a native `x86_64` Python environment with `BUILD_MACOS_ARCH=x86_64`.
 
 ## Local build on Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ $ chmod +x GridPlayer-0.5.4-x86_64.AppImage
 
 ### MacOS
 
-[![Download DMG](https://raw.githubusercontent.com/vzhd1701/gridplayer/master/resources/public/dl_dmg.png)](https://github.com/vzhd1701/gridplayer/releases/download/v0.5.4/GridPlayer.0.5.4.dmg)
+[![Download DMG](https://raw.githubusercontent.com/vzhd1701/gridplayer/master/resources/public/dl_dmg.png)](https://github.com/vzhd1701/gridplayer/releases/download/v0.5.4/GridPlayer.0.5.4_arm64.dmg)
 
-**DMG image is not signed.** You will have to add an exception to run this app.
+**DMG image is not signed and targets Apple Silicon (`arm64`).** You will have to add an exception to run this app.
 
 - [How to open an app that hasn’t been notarized or is from an unidentified developer](https://support.apple.com/en-euro/HT202491)
 - [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)

--- a/justfile
+++ b/justfile
@@ -43,6 +43,12 @@ build-macos-pyinstaller: build-requirements
 build-macos-package: build-macos-pyinstaller
     ./scripts/macos/build_dmg.sh
 
+build-macos-pyinstaller-arm64: build-requirements
+    BUILD_MACOS_ARCH=arm64 ./scripts/pyinstaller/build_mac.sh
+
+build-macos-package-arm64: build-macos-pyinstaller-arm64
+    BUILD_MACOS_ARCH=arm64 ./scripts/macos/build_dmg.sh
+
 clean-pyinstaller-dist:
     find dist -maxdepth 1 -mindepth 1 -type d -exec rm -r {} \;
 

--- a/scripts/init_app_vars.sh
+++ b/scripts/init_app_vars.sh
@@ -12,8 +12,40 @@ if ! command -v realpath &> /dev/null; then
 fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  function sed() { command gsed "$@"; }
+    command -v gsed >/dev/null 2>&1 || die "gsed is required on macOS. Run ./scripts/macos/_init_local_env.sh"
+
+    sed() {
+        command gsed "$@"
+    }
 fi
+
+normalize_macos_arch() {
+    case "$1" in
+        arm64)
+            printf '%s\n' "arm64"
+            ;;
+        x86_64|intel64)
+            printf '%s\n' "x86_64"
+            ;;
+        *)
+            die "Unsupported macOS architecture: $1"
+            ;;
+    esac
+}
+
+macos_arch_suffix() {
+    case "$1" in
+        arm64)
+            printf '%s\n' "arm64"
+            ;;
+        x86_64)
+            printf '%s\n' "intel64"
+            ;;
+        *)
+            die "Unsupported macOS architecture: $1"
+            ;;
+    esac
+}
 
 replace_app_vars() {
     TARGET_FILE="$1"
@@ -91,3 +123,8 @@ export APP_URL=$(sed -n 's/__app_url__ = "\([^"]*\).*/\1/p' "$APP_BASE_DIR/versi
 export APP_BUGTRACKER_URL=$(sed -n 's/__app_bugtracker_url__ = "\([^"]*\).*/\1/p' "$APP_BASE_DIR/version.py")
 
 export APP_CDN_URL_ROOT="https://cdn.jsdelivr.net/gh/${APP_REPO_SLUG}@v${APP_VERSION}"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export APP_TARGET_ARCH=$(normalize_macos_arch "${BUILD_MACOS_ARCH:-arm64}")
+    export APP_TARGET_ARCH_SUFFIX=$(macos_arch_suffix "$APP_TARGET_ARCH")
+fi

--- a/scripts/macos/_init_local_env.sh
+++ b/scripts/macos/_init_local_env.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 
-# Run this once before building MacOS package on local machine
+set -euo pipefail
+
+# Run this once before building the native Apple Silicon macOS package locally.
 
 check() {
-    which $1 >/dev/null
+    command -v "$1" >/dev/null 2>&1
 }
 
-# install poetry
-if ! check poetry; then
-    echo "Installing poetry"
-
-    ln -s /etc/ssl/* /Library/Frameworks/Python.framework/Versions/3.*/etc/openssl
-    curl -sSL https://install.python-poetry.org | python3 -
-    echo "export PATH=\"/Users/admin/Library/Python/3.8/bin:\$PATH\"" >> ~/.bash_profile
-    source ~/.bash_profile
+if ! check brew; then
+    printf '%s\n' "Homebrew is required to install macOS build dependencies." >&2
+    exit 1
 fi
 
-brew install gnu-sed wget node graphicsmagick imagemagick
-check create-dmg || npm install --global create-dmg
+brew install gnu-sed wget node graphicsmagick imagemagick just poetry
 
-pip3 install urllib3 virtualenv
+if ! check create-dmg; then
+    npm install --global create-dmg
+fi
+
+python3 -m pip install --upgrade pip
+
+printf '%s\n' "macOS build prerequisites installed."
+printf '%s\n' "Use a native Apple Silicon shell and run: just build-macos-package-arm64"

--- a/scripts/macos/build_dmg.sh
+++ b/scripts/macos/build_dmg.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname $0 )" && pwd )"
 
 source "scripts/init_app_vars.sh"
 
-create-dmg --overwrite "$DIST_DIR/$APP_NAME.app" "$DIST_DIR" || true
+DEFAULT_DMG_FILE="$DIST_DIR/$APP_NAME $APP_VERSION.dmg"
+TARGET_DMG_FILE="$DIST_DIR/$APP_NAME $APP_VERSION"_"$APP_TARGET_ARCH_SUFFIX.dmg"
 
-DMG_FILE=$(echo "$DIST_DIR"/GridPlayer*.dmg)
+create_default_dmg() {
+    create-dmg --overwrite "$DIST_DIR/$APP_NAME.app" "$DIST_DIR"
+}
 
-if [ "$(uname -m)" = "arm64" ]; then
-    mv "$DMG_FILE" "${DMG_FILE%.dmg}_arm64.dmg"
+create_fallback_dmg() {
+    hdiutil create \
+        -ov \
+        -fs HFS+ \
+        -srcfolder "$DIST_DIR/$APP_NAME.app" \
+        -volname "$APP_NAME" \
+        -format UDZO \
+        "$TARGET_DMG_FILE"
+}
+
+if command -v create-dmg >/dev/null 2>&1 && create_default_dmg; then
+    mv -f "$DEFAULT_DMG_FILE" "$TARGET_DMG_FILE"
 else
-    mv "$DMG_FILE" "${DMG_FILE%.dmg}_intel64.dmg"
+    echo "create-dmg failed, falling back to hdiutil packaging"
+    create_fallback_dmg
 fi

--- a/scripts/pyinstaller/build_mac.sh
+++ b/scripts/pyinstaller/build_mac.sh
@@ -1,12 +1,94 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname $0 )" && pwd )"
 
 . "scripts/init_app_vars.sh"
 
-if [ "$(uname -m)" = "arm64" ]; then
+assert_target_python_arch() {
+    PYTHON_ARCH="$(python -c 'import platform; print(platform.machine())')"
+
+    if [ "$PYTHON_ARCH" != "$APP_TARGET_ARCH" ]; then
+        die "Active Python interpreter is $PYTHON_ARCH, but BUILD_MACOS_ARCH=$APP_TARGET_ARCH. Use a native $APP_TARGET_ARCH Python interpreter."
+    fi
+}
+
+assert_target_dependency_arch() {
+    python <<'PY'
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+target_arch = os.environ["APP_TARGET_ARCH"]
+python_arch = platform.machine()
+
+if python_arch != target_arch:
+    raise SystemExit(
+        f"Active Python interpreter is {python_arch}, but BUILD_MACOS_ARCH={target_arch}. "
+        f"Use a native {target_arch} Python interpreter."
+    )
+
+paths_to_check = []
+
+from PyQt5 import QtCore
+
+qtcore_ext = Path(QtCore.__file__).resolve()
+paths_to_check.append((qtcore_ext, "PyQt5.QtCore extension"))
+
+qt_framework = qtcore_ext.parent / "Qt5" / "lib" / "QtCore.framework" / "Versions" / "5" / "QtCore"
+if qt_framework.exists():
+    paths_to_check.append((qt_framework, "QtCore framework"))
+
+try:
+    from pydantic_core import _pydantic_core
+except ModuleNotFoundError:
+    pass
+else:
+    paths_to_check.append((Path(_pydantic_core.__file__).resolve(), "pydantic-core extension"))
+
+try:
+    from objc import _objc
+except ModuleNotFoundError:
+    pass
+else:
+    paths_to_check.append((Path(_objc.__file__).resolve(), "PyObjC extension"))
+
+errors = []
+
+for path, label in paths_to_check:
+    lipo_result = subprocess.run(
+        ["lipo", "-archs", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if lipo_result.returncode == 0:
+        archs = lipo_result.stdout.strip().split()
+    else:
+        file_result = subprocess.run(
+            ["file", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        archs = file_result.stdout.strip().split()
+
+    if target_arch not in archs:
+        errors.append(f"{label}: expected {target_arch}, got {' '.join(archs) or 'unknown'} ({path})")
+
+if errors:
+    joined = "\n".join(errors)
+    raise SystemExit(
+        "Installed dependencies are not built for the requested macOS architecture:\n"
+        + joined
+    )
+PY
+}
+
+if [ "$APP_TARGET_ARCH" = "arm64" ]; then
     VLC_URL="https://get.videolan.org/vlc/3.0.21/macosx/vlc-3.0.21-arm64.dmg"
 else
     VLC_URL="https://get.videolan.org/vlc/3.0.21/macosx/vlc-3.0.21-intel64.dmg"
@@ -16,13 +98,15 @@ PYINSTALLER_VERSION="6.17.0"
 
 mkdir -p "$BUILD_DIR"
 
-init_venv "$BUILD_DIR/venv-pyinstaller"
+init_venv "$BUILD_DIR/venv-pyinstaller-$APP_TARGET_ARCH"
+assert_target_python_arch
 
 # Reduce size by installing src version of pydantic
 export PIP_NO_BINARY="pydantic"
 
 pip install -r "$BUILD_DIR/requirements.txt"
 pip install pyinstaller=="$PYINSTALLER_VERSION"
+assert_target_dependency_arch
 
 # Copy icons to build dir
 cp "$RESOURCES_DIR/icons/main/sys/macos.icns" "$BUILD_DIR/main.icns"
@@ -39,12 +123,13 @@ pyinstaller --clean --noconfirm "$BUILD_DIR/$APP_NAME.spec"
 
 echo "Embedding VLC"
 
-VLC_EMBED_SRC=$(realpath "$BUILD_DIR")/libVLC
+VLC_EMBED_SRC=$(realpath "$BUILD_DIR")/libVLC-$APP_TARGET_ARCH
+VLC_DMG="$BUILD_DIR/vlc-$APP_TARGET_ARCH.dmg"
 
 if [ ! -d "$VLC_EMBED_SRC" ]; then
-    wget -q -nc -O "$BUILD_DIR/vlc.dmg" "$VLC_URL" || true
+    wget -q -nc -O "$VLC_DMG" "$VLC_URL" || true
 
-    hdiutil attach "$BUILD_DIR/vlc.dmg"
+    hdiutil attach "$VLC_DMG"
 
     VLC_SRC="/Volumes/VLC media player/VLC.app/Contents/MacOS"
 
@@ -61,6 +146,5 @@ if [ ! -d "$VLC_EMBED_SRC" ]; then
     hdiutil detach "/Volumes/VLC media player"
 fi
 
-if [ ! -d "$DIST_DIR/$APP_NAME.app/Contents/MacOS/libVLC" ]; then
-    mv "$VLC_EMBED_SRC" "$DIST_DIR/$APP_NAME.app/Contents/MacOS/libVLC"
-fi
+rm -rf "$DIST_DIR/$APP_NAME.app/Contents/MacOS/libVLC"
+cp -a "$VLC_EMBED_SRC" "$DIST_DIR/$APP_NAME.app/Contents/MacOS/libVLC"

--- a/scripts/pyinstaller/pyinstaller_mac.spec
+++ b/scripts/pyinstaller/pyinstaller_mac.spec
@@ -19,6 +19,7 @@ def strip_list(src_list, items_to_strip):
 APP_NAME = "{APP_NAME}"
 APP_ID = "{APP_ID}"
 APP_VERSION = "{APP_VERSION}"
+APP_TARGET_ARCH = "{APP_TARGET_ARCH}"
 SRC_DIR = os.path.abspath("./{APP_MODULE}")
 BUILD_DIR = os.path.abspath("./build")
 
@@ -126,7 +127,7 @@ exe = EXE(pyz,
           upx=False,
           console=False,
           disable_windowed_traceback=False,
-          target_arch=None,
+          target_arch=APP_TARGET_ARCH,
           codesign_identity=None,
           entitlements_file=None,
           icon=os.path.join(BUILD_DIR, "main.icns"))


### PR DESCRIPTION
Closes #243 

## Summary

Adds native Apple Silicon (arm64) support to the macOS build. The scripts now make the target architecture explicit, validate that the toolchain and dependencies match it, and add dedicated `just` recipes. `arm64` is the default macOS target; Intel (`x86_64`) is still buildable via an env override.

## What's changed

- **`scripts/init_app_vars.sh`**: adds `APP_TARGET_ARCH` (from `BUILD_MACOS_ARCH`, default `arm64`) plus an arch suffix for artifact naming, so all scripts share one source of truth.
- **`scripts/pyinstaller/build_mac.sh`**: per-arch venv, downloads and embeds the matching VLC (`arm64`/`intel64`), and fails fast if the active Python or key native deps (PyQt5/Qt, `pydantic-core`, PyObjC) aren't built for the target arch. Hardened with `set -euo pipefail`.
- **`scripts/macos/build_dmg.sh`**: arch-suffixed DMG name, plus an `hdiutil` fallback when `create-dmg` is missing. Hardened with `set -euo pipefail`.
- **`scripts/macos/_init_local_env.sh`** / **`scripts/pyinstaller/pyinstaller_mac.spec`**: arch-aware local env init and PyInstaller `target_arch`.
- **`justfile`**: adds `build-macos-pyinstaller-arm64` and `build-macos-package-arm64` (existing recipes preserved).
- **Docs**: `CONTRIBUTING.md` documents the arm64 default and `BUILD_MACOS_ARCH=x86_64` override; `README.md` points the DMG link at the arm64 build; `CHANGELOG.md` gets an `## [Unreleased]` entry.

## Compatibility

- Default macOS target is now `arm64`.
- Intel builds still work via `BUILD_MACOS_ARCH=x86_64` from a native `x86_64` Python environment.
- Build and packaging only, no application code changes.

## Testing

Built the DMG on Apple Silicon with `just build-macos-package-arm64` and confirmed the app launches and plays video. The arch assertions correctly reject a mismatched Python interpreter before building.