### PR TITLE
Fix: handle invalid track metadata and duplicate closes

### DIFF
--- a/gridplayer/vlc_player/player_base.py
+++ b/gridplayer/vlc_player/player_base.py
@@ -644,6 +644,7 @@ class VlcPlayerBase(ABC):
             media_player=self._media_player,
             media_tracks=list(media_tracks),
             is_audio_only=self.media_input.is_audio_only,
+            media_uri=self.media_input.uri,
         )
 
         if not self._tracks_manager.is_video_size_initialized:

--- a/gridplayer/vlc_player/player_tracks_manager.py
+++ b/gridplayer/vlc_player/player_tracks_manager.py
@@ -1,14 +1,20 @@
 import logging
+import os
+import threading
+from datetime import datetime, timezone
 
 from gridplayer.vlc_player import vlc
 from gridplayer.vlc_player.static import NO_TRACK, AudioTrack, VideoTrack
 
+_log = logging.getLogger(__name__)
+
 
 class TracksManager:
-    def __init__(self, media_player, media_tracks, is_audio_only):
+    def __init__(self, media_player, media_tracks, is_audio_only, media_uri=None):
         self._media_player = media_player
         self._media_tracks = media_tracks
         self._is_audio_only = is_audio_only
+        self._media_uri = media_uri
 
         self._log = logging.getLogger(self.__class__.__name__)
 
@@ -18,7 +24,7 @@ class TracksManager:
             return {}
 
         return {
-            t.id: _convert_video_track(t)
+            t.id: _convert_video_track(t, self._media_uri)
             for t in self._media_tracks
             if t.type == vlc.TrackType.video
         }
@@ -30,7 +36,7 @@ class TracksManager:
     @property
     def audio_tracks(self) -> dict[int, AudioTrack]:
         return {
-            t.id: _convert_audio_track(t)
+            t.id: _convert_audio_track(t, self._media_uri)
             for t in self._media_tracks
             if t.type == vlc.TrackType.audio
         }
@@ -101,7 +107,53 @@ class TracksManager:
             return None
 
 
-def _convert_video_track(video_track):
+def _decode_track_field(value, *, media_uri, track_type, track_id, field_name, default=None):
+    """Decode a libVLC track metadata field (ctypes ``c_char_p``) into text.
+
+    libVLC hands this back as raw bytes copied straight out of the
+    container's own metadata (track name/language tag), with no guarantee
+    it's valid UTF-8 -- some muxers write it in a local codepage instead.
+    A single mangled tag must not take down the whole player process, so
+    invalid bytes are replaced rather than left to raise.
+    """
+    if value is None:
+        return default
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            _log.warning(
+                "Invalid UTF-8 in %s track #%s field %r (media=%r, pid=%s, tid=%s, "
+                "at=%s): %r (%s) -- using replacement characters",
+                track_type,
+                track_id,
+                field_name,
+                media_uri,
+                os.getpid(),
+                threading.get_ident(),
+                datetime.now(timezone.utc).isoformat(),
+                value,
+                exc,
+            )
+            return value.decode("utf-8", errors="replace")
+
+    _log.error(
+        "Unexpected type for %s track #%s field %r (media=%r): %s %r",
+        track_type,
+        track_id,
+        field_name,
+        media_uri,
+        type(value),
+        value,
+    )
+    return default
+
+
+def _convert_video_track(video_track, media_uri=None):
     vt_content = video_track.u.video.contents
 
     if all([vt_content.frame_rate_num, vt_content.frame_rate_den]):
@@ -109,32 +161,54 @@ def _convert_video_track(video_track):
     else:
         fps = None
 
+    track_kwargs = {
+        "media_uri": media_uri,
+        "track_type": "video",
+        "track_id": video_track.id,
+    }
+
     return VideoTrack(
         video_dimensions=(vt_content.width, vt_content.height),
         fps=fps,
         bitrate=video_track.bitrate,
-        language=video_track.language.decode("utf-8") if video_track.language else None,
-        description=(
-            video_track.description.decode("utf-8") if video_track.description else None
+        language=_decode_track_field(
+            video_track.language, field_name="language", **track_kwargs
         ),
-        codec=vlc.libvlc_media_get_codec_description(
-            video_track.type, video_track.codec
-        ).decode("utf-8"),
+        description=_decode_track_field(
+            video_track.description, field_name="description", **track_kwargs
+        ),
+        codec=_decode_track_field(
+            vlc.libvlc_media_get_codec_description(video_track.type, video_track.codec),
+            field_name="codec",
+            default="",
+            **track_kwargs,
+        ),
     )
 
 
-def _convert_audio_track(audio_track):
+def _convert_audio_track(audio_track, media_uri=None):
     at_content = audio_track.u.audio.contents
+
+    track_kwargs = {
+        "media_uri": media_uri,
+        "track_type": "audio",
+        "track_id": audio_track.id,
+    }
 
     return AudioTrack(
         channels=at_content.channels,
         rate=at_content.rate,
         bitrate=audio_track.bitrate,
-        language=audio_track.language.decode("utf-8") if audio_track.language else None,
-        description=(
-            audio_track.description.decode("utf-8") if audio_track.description else None
+        language=_decode_track_field(
+            audio_track.language, field_name="language", **track_kwargs
         ),
-        codec=vlc.libvlc_media_get_codec_description(
-            audio_track.type, audio_track.codec
-        ).decode("utf-8"),
+        description=_decode_track_field(
+            audio_track.description, field_name="description", **track_kwargs
+        ),
+        codec=_decode_track_field(
+            vlc.libvlc_media_get_codec_description(audio_track.type, audio_track.codec),
+            field_name="codec",
+            default="",
+            **track_kwargs,
+        ),
     )

--- a/gridplayer/widgets/video_block.py
+++ b/gridplayer/widgets/video_block.py
@@ -167,6 +167,7 @@ class VideoBlock(QWidget):
         # Runtime Params
         self._is_error = False
         self._is_active = False
+        self._is_closing = False
 
         self._title = None
         self._color = None
@@ -375,6 +376,11 @@ class VideoBlock(QWidget):
         self.close(notify=False)
 
     def close(self, notify=True):
+        if self._is_closing:
+            return
+
+        self._is_closing = True
+
         self._log.debug(f"Closing video block {self.id}")
 
         if notify:

--- a/tests/test_vlc_player_tracks_manager.py
+++ b/tests/test_vlc_player_tracks_manager.py
@@ -1,0 +1,294 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from gridplayer.vlc_player import vlc
+from gridplayer.vlc_player.player_tracks_manager import (
+    TracksManager,
+    _convert_audio_track,
+    _convert_video_track,
+    _decode_track_field,
+)
+
+INVALID_UTF8 = b"\x80"
+VALID_ASCII = b"eng"
+VALID_UNICODE = "日本語トラック".encode()
+
+
+class FakeVideoContent:
+    def __init__(self, width=1920, height=1080, frame_rate_num=30, frame_rate_den=1):
+        self.width = width
+        self.height = height
+        self.frame_rate_num = frame_rate_num
+        self.frame_rate_den = frame_rate_den
+
+
+class FakeAudioContent:
+    def __init__(self, channels=2, rate=48000):
+        self.channels = channels
+        self.rate = rate
+
+
+class FakePointer:
+    def __init__(self, contents):
+        self.contents = contents
+
+
+class FakeUnion:
+    def __init__(self, video=None, audio=None):
+        self.video = video
+        self.audio = audio
+
+
+class FakeMediaTrack:
+    def __init__(
+        self,
+        *,
+        track_id,
+        track_type,
+        language=None,
+        description=None,
+        bitrate=0,
+        codec=0,
+        video_content=None,
+        audio_content=None,
+    ):
+        self.id = track_id
+        self.type = track_type
+        self.language = language
+        self.description = description
+        self.bitrate = bitrate
+        self.codec = codec
+        self.u = FakeUnion(
+            video=FakePointer(video_content) if video_content else None,
+            audio=FakePointer(audio_content) if audio_content else None,
+        )
+
+
+def make_video_track(**kwargs):
+    kwargs.setdefault("track_id", 0)
+    kwargs.setdefault("track_type", vlc.TrackType.video)
+    kwargs.setdefault("video_content", FakeVideoContent())
+    return FakeMediaTrack(**kwargs)
+
+
+def make_audio_track(**kwargs):
+    kwargs.setdefault("track_id", 0)
+    kwargs.setdefault("track_type", vlc.TrackType.audio)
+    kwargs.setdefault("audio_content", FakeAudioContent())
+    return FakeMediaTrack(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def fake_codec_description(monkeypatch):
+    monkeypatch.setattr(
+        "gridplayer.vlc_player.player_tracks_manager.vlc.libvlc_media_get_codec_description",
+        lambda *_args: b"H264",
+    )
+
+
+class TestDecodeTrackField:
+    def test_none_returns_default(self):
+        assert (
+            _decode_track_field(
+                None,
+                media_uri="x.mkv",
+                track_type="video",
+                track_id=0,
+                field_name="language",
+            )
+            is None
+        )
+
+    def test_none_returns_custom_default(self):
+        assert (
+            _decode_track_field(
+                None,
+                media_uri="x.mkv",
+                track_type="video",
+                track_id=0,
+                field_name="codec",
+                default="",
+            )
+            == ""
+        )
+
+    def test_str_passthrough(self):
+        assert (
+            _decode_track_field(
+                "eng",
+                media_uri="x.mkv",
+                track_type="video",
+                track_id=0,
+                field_name="language",
+            )
+            == "eng"
+        )
+
+    def test_valid_ascii_bytes(self):
+        assert (
+            _decode_track_field(
+                VALID_ASCII,
+                media_uri="x.mkv",
+                track_type="video",
+                track_id=0,
+                field_name="language",
+            )
+            == "eng"
+        )
+
+    def test_valid_unicode_bytes(self):
+        assert (
+            _decode_track_field(
+                VALID_UNICODE,
+                media_uri="x.mkv",
+                track_type="video",
+                track_id=0,
+                field_name="description",
+            )
+            == "日本語トラック"
+        )
+
+    def test_invalid_utf8_bytes_falls_back_without_raising(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _decode_track_field(
+                INVALID_UTF8,
+                media_uri="bad_metadata.mkv",
+                track_type="video",
+                track_id=3,
+                field_name="language",
+            )
+
+        assert result == "�"
+        assert "bad_metadata.mkv" in caplog.text
+        assert "language" in caplog.text
+        assert "video" in caplog.text
+        assert "3" in caplog.text
+
+    def test_unexpected_type_logs_and_returns_default(self, caplog):
+        with caplog.at_level(logging.ERROR):
+            result = _decode_track_field(
+                12345,
+                media_uri="x.mkv",
+                track_type="audio",
+                track_id=1,
+                field_name="language",
+            )
+
+        assert result is None
+        assert "int" in caplog.text
+
+
+class TestConvertVideoTrack:
+    def test_normal_track(self):
+        track = make_video_track(language=b"eng", description=b"Main")
+
+        result = _convert_video_track(track, media_uri="ok.mp4")
+
+        assert result.language == "eng"
+        assert result.description == "Main"
+        assert result.codec == "H264"
+        assert result.video_dimensions == (1920, 1080)
+        assert result.fps == 30.0
+
+    def test_none_language_and_description(self):
+        track = make_video_track(language=None, description=None)
+
+        result = _convert_video_track(track, media_uri="ok.mp4")
+
+        assert result.language is None
+        assert result.description is None
+
+    def test_invalid_language_does_not_raise_and_does_not_corrupt_description(self):
+        track = make_video_track(
+            language=INVALID_UTF8, description=b"Valid description"
+        )
+
+        result = _convert_video_track(track, media_uri="broken.mkv")
+
+        assert result.language == "�"
+        assert result.description == "Valid description"
+
+    def test_invalid_description_does_not_raise_and_does_not_corrupt_language(self):
+        track = make_video_track(language=b"eng", description=INVALID_UTF8)
+
+        result = _convert_video_track(track, media_uri="broken.mkv")
+
+        assert result.language == "eng"
+        assert result.description == "�"
+
+    def test_fps_none_when_frame_rate_missing(self):
+        track = make_video_track(video_content=FakeVideoContent(frame_rate_num=0))
+
+        result = _convert_video_track(track, media_uri="ok.mp4")
+
+        assert result.fps is None
+
+
+class TestConvertAudioTrack:
+    def test_normal_track(self):
+        track = make_audio_track(language=b"spa", description=b"Commentary")
+
+        result = _convert_audio_track(track, media_uri="ok.mp4")
+
+        assert result.language == "spa"
+        assert result.description == "Commentary"
+        assert result.channels == 2
+        assert result.rate == 48000
+
+    def test_invalid_language_falls_back(self):
+        track = make_audio_track(language=INVALID_UTF8)
+
+        result = _convert_audio_track(track, media_uri="broken.mkv")
+
+        assert result.language == "�"
+
+
+class TestTracksManagerDoesNotCrashOnBadMetadata:
+    def test_mixed_good_and_bad_tracks_all_convert(self):
+        tracks = [
+            make_video_track(track_id=0, language=b"eng", description=b"Good"),
+            make_video_track(track_id=1, language=INVALID_UTF8, description=b"Bad lang"),
+            make_audio_track(track_id=0, language=b"eng"),
+            make_audio_track(track_id=1, language=INVALID_UTF8),
+        ]
+
+        manager = TracksManager(
+            media_player=None,
+            media_tracks=tracks,
+            is_audio_only=False,
+            media_uri="mixed.mkv",
+        )
+
+        video_tracks = manager.video_tracks
+        audio_tracks = manager.audio_tracks
+
+        assert len(video_tracks) == 2
+        assert len(audio_tracks) == 2
+        assert video_tracks[0].language == "eng"
+        assert video_tracks[1].language == "�"
+        assert audio_tracks[1].language == "�"
+
+    def test_many_tracks_converted_concurrently(self):
+        tracks = [
+            make_video_track(
+                track_id=i,
+                language=INVALID_UTF8 if i % 2 == 0 else b"eng",
+                description=b"desc",
+            )
+            for i in range(20)
+        ]
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(
+                executor.map(
+                    lambda t: _convert_video_track(t, media_uri="concurrent.mkv"),
+                    tracks,
+                )
+            )
+
+        assert len(results) == 20
+        for i, result in enumerate(results):
+            expected = "�" if i % 2 == 0 else "eng"
+            assert result.language == expected


### PR DESCRIPTION
Decode libVLC track metadata defensively when it contains invalid UTF-8, so malformed language or description fields cannot crash playback.

Guard VideoBlock.close() against repeated calls while the first close is in progress.

Tests: pytest tests/test_vlc_player_tracks_manager.py (16 passed); ruff check on touched files.